### PR TITLE
Minor QOL changes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -18,7 +18,7 @@ import seedu.address.model.person.Person;
  */
 public class AddCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_WORD = "addmem";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
@@ -20,6 +20,8 @@ import seedu.address.model.person.Points;
  */
 public class AddPointsCommand extends Command {
     public static final String COMMAND_WORD = "addpoints";
+    public static final String MESSAGE_CONSTRAINTS = "Points added should be greater than 0.";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds points to the person identified"
             + "Parameters: NAME " + PREFIX_POINTS + "POINTS \n"

--- a/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POINTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -23,8 +24,8 @@ public class AddPointsCommand extends Command {
     public static final String MESSAGE_CONSTRAINTS = "Points added should be greater than 0.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds points to the person identified"
-            + "Parameters: NAME " + PREFIX_POINTS + "POINTS \n"
+            + ": Adds points to the person identified" + "\n"
+            + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_POINTS + "POINTS \n"
             + "Example: " + COMMAND_WORD + " John Doe " + PREFIX_POINTS + "40";
 
     public static final String MESSAGE_ARGUMENTS = "Name: %1$s, Points: %2$i";

--- a/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
@@ -24,11 +24,9 @@ public class AddPointsCommand extends Command {
     public static final String MESSAGE_CONSTRAINTS = "Points added should be greater than 0.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds points to the person identified" + "\n"
+            + ": Adds points to the person identified. "
             + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_POINTS + "POINTS \n"
             + "Example: " + COMMAND_WORD + " John Doe " + PREFIX_POINTS + "40";
-
-    public static final String MESSAGE_ARGUMENTS = "Name: %1$s, Points: %2$i";
     public static final String MESSAGE_ADDPOINTS_SUCCESS =
             "Added %1$s points to %2$s";
     private final Name name;

--- a/src/main/java/seedu/address/logic/parser/AddPointsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPointsCommandParser.java
@@ -35,6 +35,9 @@ public class AddPointsCommandParser implements Parser<AddPointsCommand> {
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).orElse(""));
         Points points = ParserUtil.parsePoints(argMultimap.getValue(PREFIX_POINTS).orElse(""));
+        if (points.value == 0) {
+            throw new ParseException(AddPointsCommand.MESSAGE_CONSTRAINTS);
+        }
 
         return new AddPointsCommand(name, points);
     }

--- a/src/test/java/seedu/address/logic/parser/AddPointsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPointsCommandParserTest.java
@@ -50,4 +50,10 @@ public class AddPointsCommandParserTest {
         assertParseFailure(parser, " " + PREFIX_NAME + " Alice " + PREFIX_POINTS + " -50",
                 Points.MESSAGE_CONSTRAINTS); // Points.MESSAGE_CONSTRAINTS contains the message for invalid points
     }
+
+    @Test
+    public void parse_pointsZero_failure() {
+        assertParseFailure(parser, " " + PREFIX_NAME + " Alice " + PREFIX_POINTS + " 0",
+                AddPointsCommand.MESSAGE_CONSTRAINTS);
+    }
 }


### PR DESCRIPTION
A group of minor bugfixes/QOL changes

Closes #52  (Change `add` to `addmem`)
Closes #55 (Prevents `addpoints` from allowing addition of 0 points)
Closes #61 (Updating MESSAGE_USAGE of AddPointCommand to align with actual usage)
