### PR TITLE
Minor QOL improvements

### DIFF
--- a/src/main/java/seedu/address/model/item/Catalogue.java
+++ b/src/main/java/seedu/address/model/item/Catalogue.java
@@ -44,6 +44,7 @@ public class Catalogue implements Iterable<Item> {
      * Returns a clone of the item in this catalogue that has a name matching the given String
      */
     public Item findItem(String name) {
+        requireNonNull(name);
         name = name.toLowerCase();
         for (Item item: internalList) {
             String itemName = item.getName().toLowerCase();

--- a/src/main/java/seedu/address/model/item/Catalogue.java
+++ b/src/main/java/seedu/address/model/item/Catalogue.java
@@ -44,8 +44,10 @@ public class Catalogue implements Iterable<Item> {
      * Returns a clone of the item in this catalogue that has a name matching the given String
      */
     public Item findItem(String name) {
+        name = name.toLowerCase();
         for (Item item: internalList) {
-            if (item.getName().equals(name)) {
+            String itemName = item.getName().toLowerCase();
+            if (itemName.equals(name)) {
                 return item.clone();
             }
         }

--- a/src/main/java/seedu/address/model/person/MembershipPoints.java
+++ b/src/main/java/seedu/address/model/person/MembershipPoints.java
@@ -13,9 +13,9 @@ public class MembershipPoints {
      * Represents the tiers and the minimum points required to reach them, from highest to lowest.
      */
     public static final String[][] TIERS = {
-            {"PLATINUM", "1000"},
-            {"GOLD", "500"},
-            {"SILVER", "200"},
+            {"PLATINUM", "10000"},
+            {"GOLD", "5000"},
+            {"SILVER", "2000"},
             {"BRONZE", "0"},
     };
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -69,7 +69,7 @@ public class PersonCard extends UiPart<Region> {
     }
 
     private static String buildOrderString(ArrayList<Order> orders) {
-        StringBuilder orderStringBuilder = new StringBuilder("Orders:\n");
+        StringBuilder orderStringBuilder = new StringBuilder("Order History:\n");
         for (Order order : orders) {
             orderStringBuilder.append(order.toString());
             orderStringBuilder.append("\n");

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="SweetRewards" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -90,8 +90,8 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void findItem_nullItem_returnsNull() {
-        assertEquals(modelManager.findItem(null), null);
+    public void findItem_nullItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.findItem(null));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/MembershipPointsTest.java
+++ b/src/test/java/seedu/address/model/person/MembershipPointsTest.java
@@ -1,0 +1,20 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class MembershipPointsTest {
+
+    @Test
+    public void getTier_test() {
+        MembershipPoints points = new MembershipPoints(0);
+        assertEquals(points.getTier(), "BRONZE");
+        points = new MembershipPoints(2500);
+        assertEquals(points.getTier(), "SILVER");
+        points = new MembershipPoints(5000);
+        assertEquals(points.getTier(), "GOLD");
+        points = new MembershipPoints(12000);
+        assertEquals(points.getTier(), "PLATINUM");
+    }
+}


### PR DESCRIPTION
#Enhancements
- Change app name to SweetRewards
- Update tier boundaries to improve scaling
  - SILVER tier now takes 2000 points to achieve
  - GOLD tier now takes 5000 points to achieve
  - PLATINUM tier now takes 10000 points to achieve
- Label for `Orders:` in GUI changed to `Order History:`

#Bugs
- Update `addorder` to ignore case for item name
  - e.g. `i/donut` will now be accepted for an item with name `Donut`
Closes #85 