### PR TITLE
Add 'help --commands' to list all existing commands

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "src/main/java/seedu/address/ui/PersonCard.java"
+  - "src/main/java/seedu/address/ui/ResultDisplay.java"
   - "src/main/java/seedu/address/logic/model/person/orders/Order.java"

--- a/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
@@ -26,7 +26,7 @@ public class AddPointsCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds points to the person identified. "
             + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_POINTS + "POINTS \n"
-            + "Example: " + COMMAND_WORD + " John Doe " + PREFIX_POINTS + "40";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + " John Doe " + PREFIX_POINTS + "40";
     public static final String MESSAGE_ADDPOINTS_SUCCESS =
             "Added %1$s points to %2$s";
     private final Name name;

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -47,4 +47,11 @@ public class HelpCommand extends Command {
             return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
         }
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof HelpCommand // instanceof handles nulls
+                && helpType.equals(((HelpCommand) other).helpType)); // state check
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -14,8 +14,37 @@ public class HelpCommand extends Command {
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
+    public static final String COMMAND_LIST = "Command List " + "\n"
+            + "Add a member: " + AddCommand.COMMAND_WORD + "\n"
+            + "Add membership points: " + AddMemPointsCommand.COMMAND_WORD + "\n"
+            + "Add redemption points:  " + AddPointsCommand.COMMAND_WORD + "\n"
+            + "Add order: " + AddOrderCommand.COMMAND_WORD + "\n"
+            + "Clear all members: " + ClearCommand.COMMAND_WORD + "\n"
+            + "Delete a member: " + DeleteCommand.COMMAND_WORD + "\n"
+            + "Edit member details: " + EditCommand.COMMAND_WORD + "\n"
+            + "Exit the program: " + ExitCommand.COMMAND_WORD + "\n"
+            + "Find members: " + FindCommand.COMMAND_WORD + "\n"
+            + "Access user guide: " + HelpCommand.COMMAND_WORD + "\n"
+            + "List all members: " + ListCommand.COMMAND_WORD + "\n"
+            + "Seed data: " + SeedDataCommand.COMMAND_WORD;
+
+    private String helpType;
+
+    public HelpCommand() {
+        this.helpType = "";
+    }
+
+    public HelpCommand(String helpType) {
+        this.helpType = helpType;
+    }
+
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        switch (helpType) {
+        case "commands":
+            return new CommandResult(COMMAND_LIST);
+        default:
+            return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -85,7 +85,7 @@ public class AddressBookParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommandParser().parse(arguments);
 
         case AddPointsCommand.COMMAND_WORD:
             return new AddPointsCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.HelpCommand;
+
+/**
+ * Parses input arguments and creates a new HelpCommand object
+ */
+public class HelpCommandParser implements Parser<HelpCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the HelpCommand.
+     * @param args the user input string
+     * @return the parsed HelpCommand object
+     */
+    public HelpCommand parse(String args) {
+        String[] argsList = args.split(" ");
+        String commandType = null;
+        for (String arg : argsList) {
+            switch (arg) {
+
+            case "--commands":
+            case "-c":
+                commandType = "commands";
+                break;
+            default:
+                break;
+            }
+        }
+        if (commandType == null) {
+            return new HelpCommand();
+        } else {
+            return new HelpCommand(commandType);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -13,6 +13,7 @@ public class HelpCommandParser implements Parser<HelpCommand> {
      * @return the parsed HelpCommand object
      */
     public HelpCommand parse(String args) {
+        args = args.trim();
         String[] argsList = args.split(" ");
         String commandType = null;
         for (String arg : argsList) {

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -13,11 +13,19 @@ public class ResultDisplay extends UiPart<Region> {
 
     private static final String FXML = "ResultDisplay.fxml";
 
+    private static final String STARTING_MESSAGE = "Welcome to SweetRewards!" + "\n"
+            + "- Type 'help --commands' to see the list of commands available." + "\n"
+            + "- Type 'help' to view the user guide online." + "\n";
+
     @FXML
     private TextArea resultDisplay;
 
+    /**
+     * Creates a {@code ResultDisplay} with the given {@code String}.
+     */
     public ResultDisplay() {
         super(FXML);
+        resultDisplay.setText(STARTING_MESSAGE);
     }
 
     public void setFeedbackToUser(String feedbackToUser) {

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -15,7 +15,7 @@ public class ResultDisplay extends UiPart<Region> {
 
     private static final String STARTING_MESSAGE = "Welcome to SweetRewards!" + "\n"
             + "- Type 'help --commands' to see the list of commands available." + "\n"
-            + "- Type 'help' to view the user guide online." + "\n";
+            + "- Type 'help' to view the user guide online.";
 
     @FXML
     private TextArea resultDisplay;

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -15,6 +15,12 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+            assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpCommands_success() {
+        CommandResult expectedCommandResult = new CommandResult(HelpCommand.COMMAND_LIST);
+        assertCommandSuccess(new HelpCommand("commands"), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -15,7 +15,7 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-            assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.HelpCommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HelpCommandParserTest {
+
+    @Test
+    public void parse_validArgs_returnsHelpCommand() {
+        HelpCommandParser parser = new HelpCommandParser();
+        assertEquals(new HelpCommand(), parser.parse(""));
+        assertEquals(new HelpCommand(), parser.parse(" "));
+        assertEquals(new HelpCommand("commands"), parser.parse(" --commands"));
+        assertEquals(new HelpCommand("commands"), parser.parse(" -c"));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
@@ -1,9 +1,10 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.HelpCommand;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.HelpCommand;
 
 public class HelpCommandParserTest {
 


### PR DESCRIPTION
- New starting message:
```
   Welcome to SweetRewards!
  - Type 'help --commands' to see the list of commands available.
  - Type 'help' to view the user guide online.
```

- `help --commands` shows:
```
Command List 
Add a member: addmem
Add membership points: addmempts
Add redemption points:  addpoints
Add order: addorder
Clear all members: clear
Delete a member: delete
Edit member details: edit
Exit the program: exit
Find members: find
Access user guide: help
List all members: list
Seed data: seeddata
```

Closes #89 
